### PR TITLE
algo - (x,y) remapping and enable retransmit to Android and RPi

### DIFF
--- a/Algorithm/comms.py
+++ b/Algorithm/comms.py
@@ -83,9 +83,13 @@ class Communication:
                 for i in range(0, len(obstacles), 4):
                     index, x, y, direction = obstacles[i : i + 4]
 
-                    # TODO - y = (19 - y) to convert from arena's representation
-                    # at (0, 0) bottom left to our representation of (0, 0) at top left
-                    index, x, y = int(index.strip()), int(x.strip()), int(y.strip())
+                    # (19 - y) to convert from arena's representation which treats bottom-left as (0,0)
+                    # to our representation which treats top-left as (0, 0)
+                    index, x, y = (
+                        int(index.strip()),
+                        int(x.strip()),
+                        19 - int(y.strip()),
+                    )
                     direction = direction.strip()
                     direction = (
                         10
@@ -107,7 +111,9 @@ class Communication:
 
                     new_obstacles.append(Obstacle(index, x, y, direction))
 
-                logger.debug(f"Client parsed obstacles from server: {new_obstacles}")
+                logger.debug(
+                    f"Client parsed obstacles from server: {new_obstacles}. Obstacles are as per ALGO client representation"
+                )
                 return new_obstacles
 
             logger.warn(

--- a/Algorithm/tests/conftest.py
+++ b/Algorithm/tests/conftest.py
@@ -40,7 +40,9 @@ def client() -> Communication:
 def obstacles() -> str:
     """
     Returns:
-        str: The list of obstacles formatted as 'index1,x1,y1,Direction1,index2,x2,y2,Direction2,...', where 0 <= x, y <= 19 and Direction in {"N", "S", "E", "W"}
+        str: The list of obstacles formatted as 'index1,x1,y1,Direction1,index2,x2,y2,Direction2,...',
+        where 0 <= x, y <= 19 and Direction in {"N", "S", "E", "W"}.
+        The (x, y) should be in arena representation (treating bottom-left as (0, 0))
     """
-    return "0,7,18,W"
-    return "0,1,1,S,1,6,7,N,2,10,12,E,3,15,3,W,4,19,10,W,5,13,17,E"  # sample arena
+    return "0,3,3,S"
+    return "0,1,18,S,1,6,12,N,2,10,7,E,3,15,16,W,4,19,9,W,5,13,2,E"  # sample arena

--- a/Algorithm/tests/test_comms.py
+++ b/Algorithm/tests/test_comms.py
@@ -98,7 +98,10 @@ def test_get_obstacles(client: Communication, obstacles: str):
             Obstacle(
                 int(expected_index),
                 int(expected_x),
-                int(expected_y),
+                19
+                - int(
+                    expected_y
+                ),  # convert from arena representation to algo representation
                 10
                 if expected_direction == Direction.NORTH.value
                 else 11


### PR DESCRIPTION
- Android treats bottom left as (0, 0) but Algo treats top left as (0,0) - remapped (x, y) after receiving the obstacle coordinates from Android, and before sending the robot's live coordinates to Android
- Enabled ACK and retransmit logic for
    - Live location updates sent to Android
    - Image ID sent to RPi